### PR TITLE
Remove admin from topten

### DIFF
--- a/services/user-services.js
+++ b/services/user-services.js
@@ -298,6 +298,9 @@ const userServices = {
   getTopTenUsers: (req, cb) => {
     Promise.all([
       User.findAll({
+        where: {
+          role: { [Op.not]: 'admin' }
+        },
         attributes: ['id', 'name', 'account', 'email', 'avatar', 'coverPhoto', 'createdAt', 'updatedAt',
           [sequelize.literal('(SELECT COUNT (*) FROM Followships WHERE Followships.following_id = User.id )'), 'followerCount'],
           [sequelize.literal('(SELECT COUNT (*) FROM Followships WHERE Followships.follower_id = User.id )'), 'followingCount'],

--- a/services/user-services.js
+++ b/services/user-services.js
@@ -237,8 +237,7 @@ const userServices = {
           model: User,
           as: 'Followers',
           attributes: ['id', 'name', 'avatar', 'introduction', 'account']
-        }],
-        order: [['createdAt', 'DESC']]
+        }]
       }),
       Followship.findAll({
         where: { followerId: helpers.getUser(req).id },


### PR DESCRIPTION
1.修改 Get /api/users/topTen 不回傳admin身份使用者
2.移除Get /api/users/:id/followers中無用處的sequelize sorting程式碼